### PR TITLE
Improve file scanning in mods folder

### DIFF
--- a/common/src/main/java/fr/catcore/translated/server/TranslationGatherer.java
+++ b/common/src/main/java/fr/catcore/translated/server/TranslationGatherer.java
@@ -163,14 +163,14 @@ public class TranslationGatherer {
             for (int a = 1; a < values; a++) {
                 value = value + line.split("=")[a];
             }
-            langTranslations.putIfAbsent(key, value);
+            langTranslations.put(key, value);
         }
         if (translations.containsKey(code)) {
             for (Map.Entry<String, String> entry : langTranslations.entrySet()) {
-                translations.get(code).putIfAbsent(entry.getKey(), entry.getValue());
+                translations.get(code).put(entry.getKey(), entry.getValue());
             }
         } else {
-            translations.putIfAbsent(code, langTranslations);
+            translations.put(code, langTranslations);
         }
     }
 
@@ -204,7 +204,7 @@ public class TranslationGatherer {
                         BufferedReader read = new BufferedReader(new InputStreamReader(jarFile.getInputStream(zipEntry)));
                         JsonObject jsonObject = GSON.fromJson(read, JsonObject.class);
                         for (Map.Entry<String, JsonElement> entry : jsonObject.entrySet()) {
-                            translations.get(fileName).putIfAbsent(entry.getKey(), entry.getValue().getAsString());
+                            translations.get(fileName).put(entry.getKey(), entry.getValue().getAsString());
                         }
                         read.close();
                     } else if (zipEntry.getName().contains(".lang")) {


### PR DESCRIPTION
### Contents

1. Allow mods to overwrite vanilla translations when they have the same key in their asset/lang directory (discussed on Discord)
2. Remove workaround with `isTrue` boolean in favor of `!isDirectory()`
3. Fix `FileNotFoundException` exceptions when having folders or other files in the mod directory. (I often see this when people temporarily disable mods, since Fabric loader ignore subdirectories)
<details>
<summary><strong>What the error was</strong></summary>

```
[14:33:40] [main/INFO] (TranslatedServerLog) Initializing TranslatedServerLog.
[14:33:52] [main/INFO] (Minecraft) [STDERR]: java.io.FileNotFoundException: .\mods\stupid folder (Zugriff verweigert)
[14:33:52] [main/INFO] (Minecraft) [STDERR]: 	at java.util.zip.ZipFile.open(Native Method)
[14:33:52] [main/INFO] (Minecraft) [STDERR]: 	at java.util.zip.ZipFile.<init>(ZipFile.java:225)
[14:33:52] [main/INFO] (Minecraft) [STDERR]: 	at java.util.zip.ZipFile.<init>(ZipFile.java:155)
[14:33:52] [main/INFO] (Minecraft) [STDERR]: 	at java.util.jar.JarFile.<init>(JarFile.java:167)
[14:33:52] [main/INFO] (Minecraft) [STDERR]: 	at java.util.jar.JarFile.<init>(JarFile.java:131)
[14:33:52] [main/INFO] (Minecraft) [STDERR]: 	at fr.catcore.translated.server.TranslationGatherer.lookIntoModFiles(TranslationGatherer.java:194)
[14:33:52] [main/INFO] (Minecraft) [STDERR]: 	at fr.catcore.translated.server.TranslationGatherer.init(TranslationGatherer.java:43)
[14:33:52] [main/INFO] (Minecraft) [STDERR]: 	at fr.catcore.translated.server.TranslatedServerLog.onInitialize(TranslatedServerLog.java:22)
[14:33:52] [main/INFO] (Minecraft) [STDERR]: 	at net.minecraft.util.Language.handler$zzb000$server_GetInstance(Language.java:516)
[14:33:52] [main/INFO] (Minecraft) [STDERR]: 	at net.minecraft.util.Language.create(Language.java:61)
[14:33:52] [main/INFO] (Minecraft) [STDERR]: 	at net.minecraft.util.Language.<clinit>(Language.java:30)
[14:33:52] [main/INFO] (Minecraft) [STDERR]: 	at net.minecraft.text.TranslatableText.updateTranslations(TranslatableText.java:40)
[14:33:52] [main/INFO] (Minecraft) [STDERR]: 	at net.minecraft.text.TranslatableText.visitSelf(TranslatableText.java:144)
[14:33:52] [main/INFO] (Minecraft) [STDERR]: 	at net.minecraft.text.Text.visit(Text.java:120)
[14:33:52] [main/INFO] (Minecraft) [STDERR]: 	at net.minecraft.text.StringRenderable.getString(StringRenderable.java:148)
[14:33:52] [main/INFO] (Minecraft) [STDERR]: 	at net.minecraft.text.Text.getString(Text.java:56)
[14:33:52] [main/INFO] (Minecraft) [STDERR]: 	at com.mojang.brigadier.exceptions.CommandSyntaxException.<init>(CommandSyntaxException.java:27)
[14:33:52] [main/INFO] (Minecraft) [STDERR]: 	at com.mojang.brigadier.exceptions.SimpleCommandExceptionType.createWithContext(SimpleCommandExceptionType.java:21)
[14:33:52] [main/INFO] (Minecraft) [STDERR]: 	at com.mojang.brigadier.StringReader.readDouble(StringReader.java:142)
[14:33:52] [main/INFO] (Minecraft) [STDERR]: 	at net.minecraft.command.arguments.CoordinateArgument.parse(CoordinateArgument.java:31)
[14:33:52] [main/INFO] (Minecraft) [STDERR]: 	at net.minecraft.command.arguments.DefaultPosArgument.parse(DefaultPosArgument.java:79)
[14:33:52] [main/INFO] (Minecraft) [STDERR]: 	at net.minecraft.command.arguments.Vec3ArgumentType.parse(Vec3ArgumentType.java:47)
[14:33:52] [main/INFO] (Minecraft) [STDERR]: 	at net.minecraft.command.arguments.Vec3ArgumentType.parse(Vec3ArgumentType.java:27)
[14:33:52] [main/INFO] (Minecraft) [STDERR]: 	at com.mojang.brigadier.tree.ArgumentCommandNode.isValidInput(ArgumentCommandNode.java:91)
[14:33:52] [main/INFO] (Minecraft) [STDERR]: 	at com.mojang.brigadier.tree.CommandNode.findAmbiguities(CommandNode.java:105)
[14:33:52] [main/INFO] (Minecraft) [STDERR]: 	at com.mojang.brigadier.tree.CommandNode.findAmbiguities(CommandNode.java:116)
[14:33:52] [main/INFO] (Minecraft) [STDERR]: 	at com.mojang.brigadier.tree.CommandNode.findAmbiguities(CommandNode.java:116)
[14:33:52] [main/INFO] (Minecraft) [STDERR]: 	at com.mojang.brigadier.CommandDispatcher.findAmbiguities(CommandDispatcher.java:693)
[14:33:52] [main/INFO] (Minecraft) [STDERR]: 	at net.minecraft.server.command.CommandManager.<init>(CommandManager.java:132)
[14:33:52] [main/INFO] (Minecraft) [STDERR]: 	at net.minecraft.resource.ServerResourceManager.<init>(ServerResourceManager.java:33)
[14:33:52] [main/INFO] (Minecraft) [STDERR]: 	at net.minecraft.resource.ServerResourceManager.reload(ServerResourceManager.java:76)
[14:33:52] [main/INFO] (Minecraft) [STDERR]: 	at net.minecraft.server.Main.main(Main.java:123)
[14:33:52] [main/INFO] (Minecraft) [STDERR]: 	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[14:33:52] [main/INFO] (Minecraft) [STDERR]: 	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
[14:33:52] [main/INFO] (Minecraft) [STDERR]: 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[14:33:52] [main/INFO] (Minecraft) [STDERR]: 	at java.lang.reflect.Method.invoke(Method.java:498)
[14:33:52] [main/INFO] (Minecraft) [STDERR]: 	at net.fabricmc.loader.game.MinecraftGameProvider.launch(MinecraftGameProvider.java:192)
[14:33:52] [main/INFO] (Minecraft) [STDERR]: 	at net.fabricmc.loader.launch.knot.Knot.init(Knot.java:140)
[14:33:52] [main/INFO] (Minecraft) [STDERR]: 	at net.fabricmc.loader.launch.knot.KnotServer.main(KnotServer.java:26)
[14:33:52] [main/INFO] (Minecraft) [STDERR]: 	at net.fabricmc.devlaunchinjector.Main.main(Main.java:86)
```


</details>